### PR TITLE
load the library error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A modification to the [Kint debugging library](https://github.com/raveren/kint) 
 Made a few modifications to allow easy use in CodeIgniter. Simply load the library:
 
 ```php
-$this->load->library('kint');
+// linux or windows is ok
+$this->load->library('Kint/kint');
 ```
 
 And then use Kint as normal:


### PR DESCRIPTION
development linux (CentOS 6.4)
the codeigniter error:
Unable to load the requested class: kint

I made it, $this->load->library('Kint/kint');
This issue has been dealt with.
